### PR TITLE
Minify more

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ NanoEvents.prototype = {
 
     list = list.slice()
 
-    var args = [].slice.call(arguments, 1)
+    var args = list.slice.call(arguments, 1)
     for (var i = 0; list[i]; i++) {
       var l = list[i]
       l.fn.apply(this, args)

--- a/index.js
+++ b/index.js
@@ -118,9 +118,8 @@ NanoEvents.prototype = {
 
     var args = list.slice.call(arguments, 1)
     for (var i = 0; list[i]; i++) {
-      var l = list[i]
-      l.fn.apply(this, args)
-      if (l.once) l.rm()
+      list[i].fn.apply(this, args)
+      if (list[i].once) list[i].rm()
     }
 
     return true

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "260 B"
+      "limit": "258 B"
     }
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "258 B"
+      "limit": "257 B"
     }
   ],
   "lint-staged": {


### PR DESCRIPTION
- reuse `list` array
- duplicate runs of `list[i]` are more gzip friendly (and should not impose a perf overhead)