### PR TITLE
Minification: Reuse `event` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple and tiny event emitter library for JavaScript.
 
 * No Node.js [EventEmitter] compatibility.
-* Only 130 bytes (minified and gzipped). It uses [Size Limit] to control size.
+* Only 124 bytes (minified and gzipped). It uses [Size Limit] to control size.
 * `on` method returns `unbind` function. You don’t need to save
   callback to variable for `removeListener`.
 * No aliases, just `emit` and `on` methods.

--- a/index.js
+++ b/index.js
@@ -51,16 +51,12 @@ NanoEvents.prototype = {
       throw new Error('Listener must be a function')
     }
 
-    var events = this.events
-
-    if (events[event]) {
-      events[event].push(cb)
-    } else {
-      events[event] = [cb]
-    }
+    // event variable is reused and repurposed, now it's an array of handlers
+    event = this.events[event] = this.events[event] || []
+    event.push(cb)
 
     return function () {
-      events[event].splice(events[event].indexOf(cb) >>> 0, 1)
+      event.splice(event.indexOf(cb) >>> 0, 1)
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "130 B"
+      "limit": "124 B"
     }
   ],
   "lint-staged": {


### PR DESCRIPTION
Variable re-purposing based on the control flow is a common practice in optimizing compilers.
UglifyJS cannot do that, so this is done manually :grin: 