### PR TITLE
Minify: reuse arguments

### DIFF
--- a/.yaspellerrc
+++ b/.yaspellerrc
@@ -11,6 +11,7 @@
     "EventEmitter",
     "js",
     "cb",
+    "args",
     "Versioning",
     "gzipped",
     "unbindAll",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple and tiny event emitter library for JavaScript.
 
 * No Node.js [EventEmitter] compatibility.
-* Only 119 bytes (minified and gzipped). It uses [Size Limit] to control size.
+* Only 115 bytes (minified and gzipped). It uses [Size Limit] to control size.
 * `on` method returns `unbind` function. You don’t need to save
   callback to variable for `removeListener`.
 * No aliases, just `emit` and `on` methods.

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@
    * Calls each of the listeners registered for a given event.
    *
    * @param {string} event The event name.
-   * @param {...*} arguments The arguments for listeners.
+   * @param {...*} args The arguments for listeners.
    *
    * @returns {undefined}
    *
@@ -83,12 +83,13 @@
    * @alias NanoEvents#emit
    * @method
    */
-  emit: function emit (event) {
-    var list = this.events[event]
-    if (!list || !list[0]) return // list[0] === Array.isArray(list)
+  emit: function emit (event, args) {
+    // event variable is reused and repurposed, now it's an array of handlers
+    event = this.events[event]
+    if (!event || !event[0]) return // event[0] === Array.isArray(event)
 
-    var args = list.slice.call(arguments, 1)
-    list.slice().map(function (i) {
+    args = event.slice.call(arguments, 1)
+    event.slice().map(function (i) {
       i.apply(this, args) // this === global or window
     })
   }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "119 B"
+      "limit": "115 B"
     }
   ],
   "lint-staged": {


### PR DESCRIPTION
119 -> 115 bytes

This trick with variable rename again, but this time there's an extra arg is added into the signature:

```
function(a) {
  var b = 42
}
```
vs,
```
function(a,b) {
  b = 42
}
```
Not only it saves a few bytes by getting rid of the `var `. With this change the signature of `.emit` becomes the same as `.on` (after Uglify), so gzip now can use a backreference better.

The downside is I had to rename `arguments` into `args` in the jsdoc as the argument cannot be named `arguments`. The other way coud be the `//eslint:disable-next-line valid-jsdoc`, but disabling eslint is never a good option.