### PR TITLE
Size reduction by 14 B

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple and tiny event emitter library for JavaScript.
 
 * No Node.js [EventEmitter] compatibility.
-* Only 115 bytes (minified and gzipped). It uses [Size Limit] to control size.
+* Only 101 bytes (minified and gzipped). It uses [Size Limit] to control size.
 * `on` method returns `unbind` function. You don’t need to save
   callback to variable for `removeListener`.
 * No aliases, just `emit` and `on` methods.

--- a/index.js
+++ b/index.js
@@ -49,14 +49,12 @@
    * @method
    */
   emit: function emit (event) {
-    // Event variable is reused and repurposed, now it’s an array of handlers
-    event = this.events[event]
-    if (event && event[0]) { // event[0] === Array.isArray(event)
-      var args = event.slice.call(arguments, 1)
-      event.slice().map(function (i) {
+    var args = [].slice.call(arguments, 1)
+    // Array.prototype.call() returns empty array if context is not array-like
+    ;[].slice.call(this.events[event] || [])
+      .filter(function (i) {
         i.apply(this, args) // this === global or window
       })
-    }
   },
 
   /**
@@ -84,14 +82,14 @@
       throw new Error('Listener must be a function')
     }
 
-    // Event variable is reused and repurposed, now it’s an array of handlers
-    event = this.events[event] = this.events[event] || []
-    event.push(cb)
+    (this.events[event] = this.events[event] || []).push(cb)
 
     return function () {
-      // a.splice(i >>> 0, 1) === if (i !== -1) a.splice(i, 1)
-      // -1 >>> 0 === 0xFFFFFFFF, max possible array length
-      event.splice(event.indexOf(cb) >>> 0, 1)
-    }
+      this.events[event] = this.events[event].filter(
+        function (i) {
+          return i !== cb
+        }
+      )
+    }.bind(this)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanoevents",
   "version": "1.0.7",
-  "description": "Simple and tiny (115 bytes) event emitter library",
+  "description": "Simple and tiny (101 bytes) event emitter library",
   "keywords": [
     "EventEmitter",
     "Events",


### PR DESCRIPTION
Remove bitshifting hack.
Remove variables reuse.
Use `[].slice` for `Object.prototype` properties collision fix. 