### PR TITLE
Remove implicit binding of listeners to window or global objects (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ emitter.emit('tick', 5)
 // Prints 5
 ```
 
+In case of your listener relies on some particular context 
+(if it uses `this` within itself) you have to bind required 
+context explicitly before passing function in as a callback.
+
+```js
+const app = {
+  data: {
+    userId: getUserId(),
+    userVerified: false
+  },
+  showUserId() {
+    console.log(this.data.userId)
+  }
+}
+
+emitter.on('load application', app.showUserId.bind(app))
+
+emitter.emit('load application')
+// Prints user's id
+```
 
 ### Remove Listener
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@
     var args = [].slice.call(arguments, 1)
     // Array.prototype.call() returns empty array if context is not array-like
     ;[].slice.call(this.events[event] || []).filter(function (i) {
-      i.apply(this, args) // this === global or window
+      i.apply(null, args)
     })
   },
 


### PR DESCRIPTION
Please check the #20 for details.

In case you merge this PR it also maybe reasonable to bump the major version of the package because it this change will break the code of the users who pass the listeners using global context without explicit binding.