### PR TITLE
Reduce size to 69B

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,14 @@
 module.exports = function () {
-  let emitter = {
-    events: { }
-  }
-
-  emitter.emit = (event, ...args) => {
-    (emitter.events[event] || []).filter(i => i(...args))
-  }
-
-  emitter.on = (event, cb) => {
-    (emitter.events[event] = emitter.events[event] || []).push(cb)
-    return function () {
-      emitter.events[event] = emitter.events[event].filter(i => i !== cb)
+  return {
+    events: {},
+    emit (event, ...args) {
+      (this.events[event] || []).filter(i => i(...args))
+    },
+    on (event, cb) {
+      (this.events[event] = this.events[event] || []).push(cb)
+      return () => (
+        this.events[event] = this.events[event].filter(i => i !== cb)
+      )
     }
   }
-
-  return emitter
 }


### PR DESCRIPTION
I just thought it was funny to go even lower so I tried multiple combinations by extracting the variable out and then using an object, using arrow functions vs regular functions, and this is what I managed to get

---

I also found an alternative that is 67b but does not allow resetting the events which I think could be fine as it's possible to recreate the event emitter instead:

```ts
// instead of doing emitter.events = { }
emitter = createNanoEmitter()
```

That version would be

```js
module.exports = function () {
  let events = {}
  return {
    emit (event, ...args) {
      (events[event] || []).filter(i => i(...args))
    },
    on (event, cb) {
      (events[event] = events[event] || []).push(cb)
      return () => (
        events[event] = events[event].filter(i => i !== cb)
      )
    }
  }
}
```

But it made fail other tests related to being able to check `events` so I submitted this version instead