### PR TITLE
Move 'tick' entirely inside Ticker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ class Ticker {
   constructor () {
     this.emitter = createNanoEvents()
   }
-  on (...args) {
-    return this.emitter.on(...args)
+  on (callback) {
+    return this.emitter.on('tick', callback)
   }
   tick () {
     this.emitter.emit('tick')

--- a/README.md
+++ b/README.md
@@ -93,18 +93,19 @@ import createNanoEvents from 'https://cdn.jsdelivr.net/npm/nanoevents/index.js'
 ## Mixing to Object
 
 Because Nano Events API has only just 2 methods,
-you could just create proxy methods in your class.
+you could just create proxy methods in your class
+or encapsulate them entirely.
 
 ```js
 class Ticker {
-  constructor () {
+  constructor (interval) {
     this.emitter = createNanoEvents()
+    setInterval(function () {
+      this.emitter.emit('tick')
+    }, interval)
   }
   on (callback) {
     return this.emitter.on('tick', callback)
-  }
-  tick () {
-    this.emitter.emit('tick')
   }
 }
 ```


### PR DESCRIPTION
The `on()` proxy should hide the `'tick'` event string just like `tick()` does.