### PR TITLE
Export package.json to accommodate metro

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "type": "module",
   "types": "./index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": "./index.js"
   },
   "devDependencies": {


### PR DESCRIPTION
When building with metro it generates this warning:

```bash
warn Package nanoevents has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /<path_to_project>/node_modules/nanoevents/package.json
```

Adding `package.json` to the exports accommodates to avoid this problem.