### PR TITLE
Make nanoevents faster

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,6 @@ export let createNanoEvents = () => ({
   },
   on(event, cb) {
     this.events[event]?.push(cb) || (this.events[event] = [cb])
-    return (function () { this.events[event] = this.events[event]?.filter(i => cb !== i) }).bind(this)
+    return () => (this.events[event] = this.events[event]?.filter(i => cb !== i))
   }
 })

--- a/index.js
+++ b/index.js
@@ -5,17 +5,6 @@ export let createNanoEvents = () => ({
   },
   on(event, cb) {
     this.events[event]?.push(cb) || (this.events[event] = [cb])
-    return () => {
-      /* eslint-disable prefer-arrow-callback */
-      // The code is faster on V8 with anonymous function.
-      let result = (this.events[event] || []).filter(function (i) {
-        return cb !== i;
-      });
-      if (result.length) {
-        this.events[event] = result
-      } else {
-        delete this.events[event]
-      }
-    }
+    return (function () { this.events[event] = this.events[event]?.filter(i => cb !== i) }).bind(this)
   }
 })

--- a/index.js
+++ b/index.js
@@ -1,11 +1,21 @@
 export let createNanoEvents = () => ({
   events: {},
   emit(event, ...args) {
-    ;(this.events[event] || []).forEach(i => i(...args))
+    for (let i = 0, handlers = this.events[event] || [], length = handlers.length; i < length; i++) handlers[i](...args)
   },
   on(event, cb) {
-    ;(this.events[event] = this.events[event] || []).push(cb)
-    return () =>
-      (this.events[event] = (this.events[event] || []).filter(i => i !== cb))
+    this.events[event]?.push(cb) || (this.events[event] = [cb])
+    return () => {
+      /* eslint-disable prefer-arrow-callback */
+      // The code is faster on V8 with anonymous function.
+      let result = (this.events[event] || []).filter(function (i) {
+        return cb !== i;
+      });
+      if (result.length) {
+        this.events[event] = result
+      } else {
+        delete this.events[event]
+      }
+    }
   }
 })

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "size-limit": [
     {
       "import": "{ createNanoEvents }",
-      "limit": "99 B"
+      "limit": "156 B"
     }
   ],
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "size-limit": [
     {
       "import": "{ createNanoEvents }",
-      "limit": "156 B"
+      "limit": "145 B"
     }
   ],
   "prettier": {

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -8,8 +8,7 @@ let suite = new benchmark.Suite()
 
 function formatNumber(number) {
   return String(number)
-    .replace(/\d{3}$/, ',$&')
-    .replace(/^(\d|\d\d)(\d{3},)/, '$1,$2')
+    .replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,")
 }
 
 let counter = 0

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -78,10 +78,10 @@ test('removes event on no listeners', () => {
   equal(ee.events.one?.length, 1)
 
   unbind2()
-  equal(ee.events.one?.length, 0)
+  equal(ee.events.one, undefined)
 
   unbind2()
-  equal(ee.events.one?.length, 0)
+  equal(ee.events.one, undefined)
 })
 
 test('removes listener during event', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -78,10 +78,10 @@ test('removes event on no listeners', () => {
   equal(ee.events.one?.length, 1)
 
   unbind2()
-  equal(ee.events.one, undefined)
+  equal(ee.events.one?.length, 0)
 
   unbind2()
-  equal(ee.events.one, undefined)
+  equal(ee.events.one?.length, 0)
 })
 
 test('removes listener during event', () => {


### PR DESCRIPTION
As a follow up of the discussion in https://github.com/ai/nanoevents/issues/62

The change makes the package about 50% bigger (159 vs 99 bytes currently), but at the same time runtime performance [seems to be improved](https://jsbench.me/k4l45p7eyh/4) (on M1 Pro):
- Chrome and Node.js: about 50% improvement: 57k vs 38k ops/s for the current code,
- Safari: 4x improvement: 60k vs 15k ops/s
- Firefox: 80% improvement: 18k vs 10k ops/s

Changes:
- `emit`: Use for loop to iterate over event handlers.
  - Before: use `forEach`.
  - Rationale: for loop is faster.
- `on`: Push when event handlers are available, or assign the handlers to an array with callback.
  - Before: create an empty array and push, if the event handlers array is not defined.
  - Rationale: the code is faster. 
- `unbind`: Use function expression in `filter` expression in `unbind` function.
  - Before: used arrow function.
  - Rationale: on V8 function expression is faster inside `filter`, on other engines they are equal.
- `unbind`: Delete event handlers array if it is to be empty in `unbind` function. BTW, this changes one of the tests slightly.
  - Before: retain an empty array.
  - Rationale: performance, as a side-effect this removes a [memory leak](https://github.com/ai/nanoevents/issues/38)